### PR TITLE
'use encoding' is gone in perl 5.26

### DIFF
--- a/bin/oai_pmh.pl
+++ b/bin/oai_pmh.pl
@@ -1,7 +1,5 @@
 #!/usr/bin/perl
 
-use encoding 'utf8';
-
 use HTTP::OAI;
 use Getopt::Long;
 use Pod::Usage;


### PR DESCRIPTION

In Debian we are currently applying the following patch to HTTP-OAI.
We thought you might be interested in it too.

    Description: 'use encoding' is gone in perl 5.26
     Simply remove it for now; the code is ascii anyway, and
     if the output needs utf-8, other solutions can be found.
    Origin: vendor
    Bug-Debian: https://bugs.debian.org/866934
    Author: gregor herrmann <gregoa@debian.org>
    Last-Update: 2017-07-15
    

The patch is tracked in our Git repository at
https://anonscm.debian.org/cgit/pkg-perl/packages/libhttp-oai-perl.git/plain/debian/patches/use-encoding.patch

Thanks for considering,
  gregor herrmann,
  Debian Perl Group
