### PR TITLE
Fix validate_metadataPrefix regex

### DIFF
--- a/lib/HTTP/OAI/Repository.pm
+++ b/lib/HTTP/OAI/Repository.pm
@@ -173,9 +173,9 @@ sub validate_setSpec_2_0 {
 
 sub validate_metadataPrefix {
 	return
-		shift =~ /^[\w]+$/ ?
+		shift =~ /^[A-Za-z0-9\-_\.!\~\*\'\(\)]+$/ ?
 		0 :
-		"Metadata prefix not in OAI format, must match regexp ^[\\w]+\$";
+		"Metadata prefix not in OAI format, must match regexp ^[A-Za-z0-9\\-_\\.!\\~\\*\\'\\(\\)]+\$/";
 }
 
 # OAI 2 requires identifiers by valid URIs


### PR DESCRIPTION
Hi,

I was trying to fetch records from http://oai.esrc.unimelb.edu.au/EOASnew/provider?verb=ListRecords&metadataPrefix=eac-cpf but was getting errors about the metadata prefix. The dash in `eac-cpf` was causing it to be rejected.

It looks like the regex in `validate_metadataPrefix` isn't quite right.

http://www.openarchives.org/OAI/openarchivesprotocol.html#MetadataNamespaces
says:

> metadataPrefix consists of any valid URI unreserved characters.

That links to https://www.ietf.org/rfc/rfc2396.txt, which has:

```
    unreserved    = alphanum | mark

    mark          = "-" | "_" | "." | "!" | "~" | "*" | "'" | "(" | ")"

    alphanum      = alpha | digit

    alpha         = lowalpha | upalpha

    lowalpha = "a" | "b" | "c" | "d" | "e" | "f" | "g" | "h" | "i" |
               "j" | "k" | "l" | "m" | "n" | "o" | "p" | "q" | "r" |
               "s" | "t" | "u" | "v" | "w" | "x" | "y" | "z"
    upalpha  = "A" | "B" | "C" | "D" | "E" | "F" | "G" | "H" | "I" |
               "J" | "K" | "L" | "M" | "N" | "O" | "P" | "Q" | "R" |
               "S" | "T" | "U" | "V" | "W" | "X" | "Y" | "Z"
    digit    = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" |
               "8" | "9"
```

I've changed the regex to match this definition.