### PR TITLE
 Support 429 Retry-After header

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for HTTP-OAI
 
 {{$NEXT}}
+  - Support 429 Too Many Requests (RFC6585)
 
 4.08  2018-11-26 11:29:41 CET
   - Fixing passing DOM to HTTP::OAI::Metadata

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM perl:5.30
+
+COPY . /usr/src/app
+WORKDIR /usr/src/app
+RUN cpanm --quiet . LWP::Protocol::https
+#RUN cpanm --quiet --installdeps --notest --force --skip-satisfied .
+#RUN cpanm --quiet --notest --skip-satisfied Devel::Cover
+#RUN perl Build.PL && ./Build build && cover -test
+
+# For compatibility with Debian suffix-less scripts
+RUN ln -s /usr/local/bin/oai_browser.pl /usr/local/bin/oai_browser && \
+    ln -s /usr/local/bin/oai_pmh.pl /usr/local/bin/oai_pmh
+
+WORKDIR /tmp
+CMD ["/usr/local/bin/oai_browser"]

--- a/lib/HTTP/OAI/UserAgent.pm
+++ b/lib/HTTP/OAI/UserAgent.pm
@@ -103,7 +103,7 @@ HTTP::OAI::Debug::trace( $args{verb} . " " . ref($parser) . "->parse_chunk()" );
 	undef $parser;
 
 	# OAI retry-after
-	if( defined($r) && $r->code == 503 && defined(my $timeout = $r->headers->header('Retry-After')) ) {
+	if( defined($r) && ( $r->code == 503 || $r->code == 429  ) && defined(my $timeout = $r->headers->header('Retry-After')) ) {
 		if( $self->{recursion}++ > 10 ) {
 			$r->code(500);
 			$r->message("Server did not give a response after 10 retries");


### PR DESCRIPTION
Support for [RFC6585](https://tools.ietf.org/html/rfc6585) HTTP status code `429 Too Many Requests` with `Retry-After` logic.

https://www.openarchives.org/OAI/openarchivesprotocol.html#StatusCodes
do suggest  503 for this purpose (which already works here), but it is not a mandated. 

https://zenodo.org/oai2d however return `429 Too Many Requests` instead of `503 Service Unavailable`.

After the patch the below should not fail early (but may take a long time):

    oai_pmh --request ListIdentifiers --metadataPrefix oai_dc https://zenodo.org/oai2d

For testing/deployment I also added a `Dockerfile`, feel free to ignore 5825b45 if this is inappropriate (see https://hub.docker.com/r/stain/perl-oai-lib )