### PR TITLE
Do not use lib from relative paths

### DIFF
--- a/script/oai_browser.pl
+++ b/script/oai_browser.pl
@@ -57,9 +57,6 @@ BEGIN {
 
 use vars qw($VERSION $h);
 
-use lib "../lib";
-use lib "lib";
-
 use HTTP::OAI;
 use Pod::Usage;
 


### PR DESCRIPTION
If a user is in a directory where an attack has write access (e.g. /tmp), the attacker can create ./lib/HTTP/OAI.pm file and when the user executes oai_browser.pl, the malicous ./lib/HTTP/OAI.pm file will be loaded and executed.

This pach fixes this vulnerablity by removing the unhelpful "use lib" commands from oai_browser.pl.